### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It allows people to collaborate on spreadsheets over the internet in real time.
 
 Join the project or see it in action at https://www.ethersheet.org
 
-#For Users
+# For Users
 1. Download the latest version of ethesheet from https://ethersheet.org/releases/ethersheet_latest.tgz
 2. Unpack the tarball and run the script named `install.sh`
 3. run npm start and navigate to localhost:8080
@@ -14,15 +14,15 @@ Join the project or see it in action at https://www.ethersheet.org
 ## Verifying the package
 You can verify the authenticity of the tarball by checking its signature with our gpg key. You can always find the latest signature file at https://ethersheet.org/releases/ethersheet_latest.tgz.sig and you can find our key at https://ethersheet.org/static/ethersheet_gpg_key.asc
 
-#For Developers
+# For Developers
 1. Run the following command in your terminal:
 `curl https://raw.githubusercontent.com/ethersheet-collective/EtherSheet/master/dev_install.sh | bash`
 2. copy examples/config-example.js to config.js in the EtherSheet directory
 3. edit config and put in the database name as well as the username and password
 
-#Dependencies
+# Dependencies
 Ethersheet is only supported on GNU/Linux and MySQL as of right now. It's possible that it will work on Windows or with PostgreSQL or some other database, but we haven't tested it on those platforms. If you want to submit a feature, send a pull request and we will look it over and accept it if it looks good.
 
-#Running tests
+# Running tests
 To run server tests run `npm test` in the EtherSheet server directory
 Simply navigate to [http://localhost:8080/es_client/test/](http://localhost:8080/es_client/test/) to run client tests.

--- a/notes.md
+++ b/notes.md
@@ -8,14 +8,14 @@
 *Expression
 *CellValue
 
-##Views
+## Views
 *Table
 *ExpressionEditor
 *TableControls
 *ConnectedUsers
 *SettingsEditor
 
-#Transport
+# Transport
 *SocketConnection
 
 Implementation Notes


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
